### PR TITLE
install jdk11

### DIFF
--- a/ansible/playbooks/all.yml
+++ b/ansible/playbooks/all.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   roles:
-    - ansible
+    - software
     - wireguard
     - firewalld
     - caddy

--- a/ansible/roles/software/tasks/main.yml
+++ b/ansible/roles/software/tasks/main.yml
@@ -7,3 +7,7 @@
   yum:
     name: ansible
     state: latest
+- name: ensure OpenJDK 11 is installed
+  yum:
+    name: java-11-openjdk
+    state: latest


### PR DESCRIPTION
While moving T2 to a new datacenter, we recognized that Java was not installed via Ansible -> fixed