### PR TITLE
Changes version constraints to allow running this with Terraform 1.0

### DIFF
--- a/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
+++ b/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 terraform {

--- a/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
+++ b/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 terraform {

--- a/templates/_common/terraform_modules/master_keypair/master_keypair.tf
+++ b/templates/_common/terraform_modules/master_keypair/master_keypair.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 variable "filename" {

--- a/templates/_common/terraform_modules/master_keypair/master_keypair.tf
+++ b/templates/_common/terraform_modules/master_keypair/master_keypair.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 variable "filename" {

--- a/templates/_common/terraform_modules/stackable_package_versions_centos/stackable_package_versions_centos.tf
+++ b/templates/_common/terraform_modules/stackable_package_versions_centos/stackable_package_versions_centos.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 # variable file for Ansible containing packages/versions of Stackable components

--- a/templates/_common/terraform_modules/stackable_package_versions_centos/stackable_package_versions_centos.tf
+++ b/templates/_common/terraform_modules/stackable_package_versions_centos/stackable_package_versions_centos.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 # variable file for Ansible containing packages/versions of Stackable components

--- a/templates/_common/terraform_modules/stackable_package_versions_debian/stackable_package_versions_debian.tf
+++ b/templates/_common/terraform_modules/stackable_package_versions_debian/stackable_package_versions_debian.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 # variable file for Ansible containing packages/versions of Stackable components

--- a/templates/_common/terraform_modules/stackable_package_versions_debian/stackable_package_versions_debian.tf
+++ b/templates/_common/terraform_modules/stackable_package_versions_debian/stackable_package_versions_debian.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 # variable file for Ansible containing packages/versions of Stackable components

--- a/templates/_common/terraform_modules/wireguard/wireguard.tf
+++ b/templates/_common/terraform_modules/wireguard/wireguard.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 variable "server_config_filename" {

--- a/templates/_common/terraform_modules/wireguard/wireguard.tf
+++ b/templates/_common/terraform_modules/wireguard/wireguard.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 variable "server_config_filename" {

--- a/templates/demo-centos-7/main.tf
+++ b/templates/demo-centos-7/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 terraform {

--- a/templates/demo-centos-7/main.tf
+++ b/templates/demo-centos-7/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 terraform {

--- a/templates/demo-centos-8/main.tf
+++ b/templates/demo-centos-8/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 terraform {

--- a/templates/demo-centos-8/main.tf
+++ b/templates/demo-centos-8/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 terraform {

--- a/templates/demo-debian-10/main.tf
+++ b/templates/demo-debian-10/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.15"
+  required_version = ">= 0.15"
 }
 
 terraform {

--- a/templates/demo-debian-10/main.tf
+++ b/templates/demo-debian-10/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.15"
+  required_version = ">= 0.15, < 2.0.0"
 }
 
 terraform {


### PR DESCRIPTION
Release notes for Terraform 1.0.0 are here: https://github.com/hashicorp/terraform/blob/v1.0/CHANGELOG.md#100-june-08-2021

Most notable excerpt: 

> Terraform v1.0.0 intentionally has no significant changes compared to Terraform v0.15.5. You can consider the v1.0 series as a direct continuation of the v0.15 series; we do not intend to issue any further releases in the v0.15 series, because all of the v1.0 releases will be only minor updates to address bugs.

I have tested this by manually changing it in the generated terraform files and it worked fine for me.
@ftrossbach also ran it with that change and confirmed it as working for him.

fixes #102 