### PR TITLE
k3s installation: removed cluster-signing params

### DIFF
--- a/templates/_common/ansible_roles/stackable_k3s/tasks/main.yml
+++ b/templates/_common/ansible_roles/stackable_k3s/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 - name: Install K3s w/ rancher script
-  shell: |
-    curl -sfL https://get.k3s.io | sh -s - \
-    --kube-controller-manager-arg cluster-signing-cert-file= \
-    --kube-controller-manager-arg cluster-signing-key-file= \
-    --kube-controller-manager-arg cluster-signing-kube-apiserver-client-cert-file=/var/lib/rancher/k3s/server/tls/client-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kube-apiserver-client-key-file=/var/lib/rancher/k3s/server/tls/client-ca.key \
-    --kube-controller-manager-arg cluster-signing-kubelet-client-cert-file=/var/lib/rancher/k3s/server/tls/client-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kubelet-client-key-file=/var/lib/rancher/k3s/server/tls/client-ca.key \
-    --kube-controller-manager-arg cluster-signing-kubelet-serving-cert-file=/var/lib/rancher/k3s/server/tls/server-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kubelet-serving-key-file=/var/lib/rancher/k3s/server/tls/server-ca.key
+  shell: curl -sfL https://get.k3s.io | sh -s
   args:
     warn: no
     creates: /etc/rancher/k3s/k3s.yaml

--- a/templates/_common/ansible_roles/stackable_k3s_non_root/tasks/main.yml
+++ b/templates/_common/ansible_roles/stackable_k3s_non_root/tasks/main.yml
@@ -1,15 +1,6 @@
 ---
 - name: Install K3s w/ rancher script
-  shell: |
-    curl -sfL https://get.k3s.io | sh -s - \
-    --kube-controller-manager-arg cluster-signing-cert-file= \
-    --kube-controller-manager-arg cluster-signing-key-file= \
-    --kube-controller-manager-arg cluster-signing-kube-apiserver-client-cert-file=/var/lib/rancher/k3s/server/tls/client-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kube-apiserver-client-key-file=/var/lib/rancher/k3s/server/tls/client-ca.key \
-    --kube-controller-manager-arg cluster-signing-kubelet-client-cert-file=/var/lib/rancher/k3s/server/tls/client-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kubelet-client-key-file=/var/lib/rancher/k3s/server/tls/client-ca.key \
-    --kube-controller-manager-arg cluster-signing-kubelet-serving-cert-file=/var/lib/rancher/k3s/server/tls/server-ca.crt \
-    --kube-controller-manager-arg cluster-signing-kubelet-serving-key-file=/var/lib/rancher/k3s/server/tls/server-ca.key
+  shell: curl -sfL https://get.k3s.io | sh -s
   args:
     warn: no
     creates: /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
closes #75 

k3s installation: removed heaps of cluster-signing related params as they are no longer required due to @siegfriedweber's fix