### PR TITLE
update scripts: refresh package versions before showing options to user

### DIFF
--- a/templates/_common/ansible_roles/stackable_update_agent/tasks/main.yml
+++ b/templates/_common/ansible_roles/stackable_update_agent/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure agent is installed
+- name: Ensure agent is installed (YUM)
   yum:
     name: "stackable-agent-{{ version }}"
     state: present
@@ -7,7 +7,7 @@
   when: 
     - (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")
 
-- name: Ensure agent is installed
+- name: Ensure agent is installed (APT)
   apt:
     name: "stackable-agent={{ version }}"
     state: present
@@ -15,7 +15,7 @@
   when: 
     - ansible_distribution == "Debian"
 
-- name: Restart operator
+- name: Restart agent
   systemd:
     name: "stackable-agent"
     state: restarted

--- a/templates/_common/ansible_roles/stackable_update_operator/tasks/main.yml
+++ b/templates/_common/ansible_roles/stackable_update_operator/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Ensure operator is installed
+- name: Ensure operator is installed (YUM)
   yum:
     name: "stackable-{{ operator }}-operator-server-{{ version }}"
     state: present
@@ -7,7 +7,7 @@
   when: 
     - (ansible_distribution == "CentOS") or (ansible_distribution == "RedHat")
 
-- name: Ensure operator is installed
+- name: Ensure operator is installed (APT)
   apt:
     name: "stackable-{{ operator }}-operator-server={{ version }}"
     state: present

--- a/templates/demo-centos-7/update_agent.sh
+++ b/templates/demo-centos-7/update_agent.sh
@@ -3,6 +3,7 @@
 echo
 echo "Reading installed version for stackable-agent.x86_64..."
 echo
+sh resources/stackable.sh nodes "yum clean all 1>/dev/null 2>&1"
 sh resources/stackable.sh nodes "yum list installed 2> /dev/null | grep 'stackable-agent.x86_64'"
 echo
 echo "Available versions: "

--- a/templates/demo-centos-7/update_operator.sh
+++ b/templates/demo-centos-7/update_operator.sh
@@ -3,6 +3,7 @@
 echo
 echo "List of available operators"
 echo
+sh resources/stackable.sh orchestrator "yum clean all 1>/dev/null 2>&1"
 { 
     echo "`sh resources/stackable.sh orchestrator "yum list installed 2> /dev/null | grep 'stackable'" | grep 'operator-server' | sed 's/stackable-//' | sed 's/-operator-server.x86_64.*//'`" ;
     echo "`sh resources/stackable.sh orchestrator "yum list available 2> /dev/null | grep 'stackable'" | grep 'operator-server' | sed 's/stackable-//' | sed 's/-operator-server.x86_64.*//'`" ; 

--- a/templates/demo-centos-8/update_agent.sh
+++ b/templates/demo-centos-8/update_agent.sh
@@ -3,6 +3,7 @@
 echo
 echo "Reading installed version for stackable-agent.x86_64..."
 echo
+sh resources/stackable.sh nodes "yum clean all 1>/dev/null 2>&1"
 sh resources/stackable.sh nodes "yum list installed 2> /dev/null | grep 'stackable-agent.x86_64'"
 echo
 echo "Available versions: "

--- a/templates/demo-centos-8/update_operator.sh
+++ b/templates/demo-centos-8/update_operator.sh
@@ -3,6 +3,7 @@
 echo
 echo "List of available operators"
 echo
+sh resources/stackable.sh orchestrator "yum clean all 1>/dev/null 2>&1"
 { 
     echo "`sh resources/stackable.sh orchestrator "yum list installed 2> /dev/null | grep 'stackable'" | grep 'operator-server' | sed 's/stackable-//' | sed 's/-operator-server.x86_64.*//'`" ;
     echo "`sh resources/stackable.sh orchestrator "yum list available 2> /dev/null | grep 'stackable'" | grep 'operator-server' | sed 's/stackable-//' | sed 's/-operator-server.x86_64.*//'`" ; 

--- a/templates/demo-debian-10/update_agent.sh
+++ b/templates/demo-debian-10/update_agent.sh
@@ -3,6 +3,8 @@
 echo
 echo "Reading installed version for stackable-agent..."
 echo
+sh resources/stackable.sh orchestrator "apt update"
+echo
 sh resources/stackable.sh nodes "apt list -a stackable-agent 2> /dev/null" | grep stackable
 echo
 read -p "Which version do you want to update to? " version

--- a/templates/demo-debian-10/update_operator.sh
+++ b/templates/demo-debian-10/update_operator.sh
@@ -3,6 +3,8 @@
 echo
 echo "List of available operators"
 echo
+sh resources/stackable.sh orchestrator "apt update"
+echo
 sh resources/stackable.sh orchestrator "apt list stackable-* 2> /dev/null" | grep 'operator-server' | sed 's/stackable-//' | sed 's/-operator-server.*//'
 echo
 echo


### PR DESCRIPTION
The scripts to update the Stackable components (Agents, Operators) in the cluster did work on cached versions of the package lists. To always use the newest set of versions, the script refreshes the list right before retrieving the options and presenting them to the user.