### PR TITLE
fixed default version of Stackable agent

### DIFF
--- a/templates/aws-centos-8/default_versions.yml
+++ b/templates/aws-centos-8/default_versions.yml
@@ -1,5 +1,5 @@
 ---
-stackable-agent: "*0.el8.x86_64"
+stackable-agent: "*-0.el8.x86_64"
 stackable-spark-operator-server: "*"
 stackable-zookeeper-operator-server: "*"
 stackable-kafka-operator-server: "*"

--- a/templates/demo-centos-7/default_versions.yml
+++ b/templates/demo-centos-7/default_versions.yml
@@ -1,5 +1,5 @@
 ---
-stackable-agent: "*0.el7"
+stackable-agent: "*-0.el7"
 stackable-spark-operator-server: "*"
 stackable-zookeeper-operator-server: "*"
 stackable-kafka-operator-server: "*"

--- a/templates/demo-centos-8/default_versions.yml
+++ b/templates/demo-centos-8/default_versions.yml
@@ -1,5 +1,5 @@
 ---
-stackable-agent: "*0.el8.x86_64"
+stackable-agent: "*-0.el8.x86_64"
 stackable-spark-operator-server: "*"
 stackable-zookeeper-operator-server: "*"
 stackable-kafka-operator-server: "*"


### PR DESCRIPTION
The default version of the Stackable Agent should be the latest release which was coded in a regex. Unfortunately the versions belonging to pull requests which were ending with a `0` also matched and could be preferred to the release versions. With this PR this regex is fixed to always prefer the release version.