### PR TITLE
Issue 133 stackable user info in every inventory

### DIFF
--- a/templates/_common/terraform_modules/aws_ansible_inventory/aws_ansible_inventory.tf
+++ b/templates/_common/terraform_modules/aws_ansible_inventory/aws_ansible_inventory.tf
@@ -20,6 +20,16 @@ variable "cluster_ip" {
   description = "Public IP of cluster"
 }
 
+variable "stackable_user" {
+  type = string
+  description = "User for Stackable stuff"
+}
+
+variable "stackable_user_home" {
+  type = string
+  description = "Home directory of Stackable user"
+}
+
 # variable file for Ansible
 resource "local_file" "ansible-variables" {
   filename = "inventory/group_vars/all/all.yml"
@@ -39,6 +49,8 @@ resource "local_file" "ansible-inventory" {
   filename = "inventory/inventory"
   content = templatefile("${path.module}/templates/ansible-inventory.tpl",
     {
+      stackable_user = var.stackable_user
+      stackable_user_home = var.stackable_user_home
       domain = yamldecode(file("cluster.yaml"))["domain"]
       nodes = var.nodes
       cluster_ip = var.cluster_ip

--- a/templates/_common/terraform_modules/aws_ansible_inventory/templates/ansible-inventory.tpl
+++ b/templates/_common/terraform_modules/aws_ansible_inventory/templates/ansible-inventory.tpl
@@ -1,12 +1,13 @@
 [all:vars]
 domain=${domain}
-stackable_user=ec2-user
+stackable_user=${stackable_user}
+stackable_user_home=${stackable_user_home}
 
 [bastion_host]
 ${cluster_ip}
 
 [bastion_host:vars]
-ansible_user=ec2-user
+ansible_user=${stackable_user}
 ansible_ssh_private_key_file=${ssh_key_private_path}
 wireguard=${wireguard}
 ansible_become=yes
@@ -17,18 +18,18 @@ ${node.tags["hostname"]} ansible_host=${node.private_ip} stackable_agent=${node.
 %{ endfor ~}
 
 [nodes:vars]
-ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ec2-user@${cluster_ip}'
+ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ${stackable_user}@${cluster_ip}'
 ansible_ssh_private_key_file=${ssh_key_private_path}
-ansible_user=ec2-user
+ansible_user=${stackable_user}
 ansible_become=yes
 
 [orchestrators]
 orchestrator ansible_host=${orchestrator.private_ip}
 
 [orchestrators:vars]
-ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ec2-user@${cluster_ip}'
+ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ${stackable_user}@${cluster_ip}'
 ansible_ssh_private_key_file=${ssh_key_private_path}
-ansible_user=ec2-user
+ansible_user=${stackable_user}
 ansible_become=yes
 
 [protected:children]

--- a/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
+++ b/templates/_common/terraform_modules/ionos_protected_cluster/ionos_protected_cluster.tf
@@ -45,6 +45,8 @@ locals {
       }
     ]
   ])
+  stackable_user = "root"
+  stackable_user_home = "/root/"
 }
 
 data "ionoscloud_image" "os_image" {
@@ -189,6 +191,8 @@ resource "local_file" "ansible-inventory" {
   filename = "inventory/inventory"
   content = templatefile("${path.module}/templates/ansible-inventory.tpl",
     {
+      stackable_user = local.stackable_user
+      stackable_user_home = local.stackable_user_home
       domain = yamldecode(file("cluster.yaml"))["domain"]
       nodes = ionoscloud_server.node
       nodes_has_agent = [ for node in local.nodes : node.agent ]

--- a/templates/_common/terraform_modules/ionos_protected_cluster/templates/ansible-inventory.tpl
+++ b/templates/_common/terraform_modules/ionos_protected_cluster/templates/ansible-inventory.tpl
@@ -1,13 +1,16 @@
 [all:vars]
 domain=${domain}
+stackable_user=${stackable_user}
+stackable_user_home=${stackable_user_home}
 
 [nat]
 ${nat_public_ip} internal_ip=${nat_internal_ip}
 
 [nat:vars]
-ansible_user=root 
+ansible_user=${stackable_user}
 ansible_ssh_private_key_file=${ssh_key_private_path}
 wireguard=${wireguard}
+ansible_become=yes
 
 [nodes]
 %{ for index, node in nodes ~}
@@ -15,17 +18,17 @@ ${node.name} ansible_host=${node.primary_ip} stackable_agent=${nodes_has_agent[i
 %{ endfor ~}
 
 [nodes:vars]
-ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q root@${nat_public_ip}'
+ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ${stackable_user}@${nat_public_ip}'
 ansible_ssh_private_key_file=${ssh_key_private_path}
-ansible_user=root
+ansible_user=${stackable_user}
 
 [orchestrators]
 orchestrator ansible_host=${orchestrator.primary_ip}
 
 [orchestrators:vars]
-ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q root@${nat_public_ip}'
+ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -i ${ssh_key_private_path} -W %h:%p -q ${stackable_user}@${nat_public_ip}'
 ansible_ssh_private_key_file=${ssh_key_private_path}
-ansible_user=root
+ansible_user=${stackable_user}
 
 [protected:children]
 nodes

--- a/templates/_common/terraform_modules/openstack_inventory/openstack_inventory.tf
+++ b/templates/_common/terraform_modules/openstack_inventory/openstack_inventory.tf
@@ -29,7 +29,12 @@ variable "bastion_host_internal_ip" {
 
 variable "stackable_user" {
   type = string
-  description = "non-root user for Stackable"
+  description = "User for Stackable stuff"
+}
+
+variable "stackable_user_home" {
+  type = string
+  description = "Home directory of Stackable user"
 }
 
 # variable file for Ansible
@@ -52,6 +57,7 @@ resource "local_file" "ansible-inventory" {
   content = templatefile("${path.module}/templates/ansible-inventory.tpl",
     {
       stackable_user = var.stackable_user
+      stackable_user_home = var.stackable_user_home
       domain = yamldecode(file("cluster.yaml"))["domain"]
       nodes = var.nodes
       cluster_ip = var.cluster_ip

--- a/templates/_common/terraform_modules/openstack_inventory/templates/ansible-inventory.tpl
+++ b/templates/_common/terraform_modules/openstack_inventory/templates/ansible-inventory.tpl
@@ -1,6 +1,7 @@
 [all:vars]
 domain=${domain}
 stackable_user=${stackable_user}
+stackable_user_home=${stackable_user_home}
 
 [bastion_host]
 bastion_host ansible_host=${cluster_ip}

--- a/templates/aws-centos-8/main.tf
+++ b/templates/aws-centos-8/main.tf
@@ -25,6 +25,11 @@ provider "aws" {
   secret_key  = var.aws_secret_access_key
 }
 
+locals {
+  stackable_user = "ec2-user"
+  stackable_user_home = "/home/ec2-user/"
+}
+
 module "master_keypair" {
   source      = "./terraform_modules/master_keypair"
   filename    = "${path.module}/cluster_key"
@@ -65,6 +70,8 @@ module "aws_ansible_inventory" {
   orchestrator                  = module.aws_protected_nodes.orchestrator
   cluster_private_key_filename  = "${path.module}/cluster_key"
   cluster_ip                    = module.aws_nat.cluster_ip
+  stackable_user                = local.stackable_user
+  stackable_user_home           = local.stackable_user_home
 }
 
 
@@ -75,7 +82,7 @@ module "stackable_client_script" {
   ]
   orchestrator_ip               = module.aws_protected_nodes.orchestrator.private_ip
   cluster_ip                    = module.aws_nat.cluster_ip
-  ssh-username                  = "ec2-user"
+  ssh-username                  = local.stackable_user
 }
 
 module "stackable_package_versions_centos" {

--- a/templates/pluscloud-open-centos-8/main.tf
+++ b/templates/pluscloud-open-centos-8/main.tf
@@ -79,7 +79,8 @@ provider "openstack" {
 }
 
 locals {
-  stackable_user_name = "centos"
+  stackable_user = "centos"
+  stackable_user_home = "/home/centos/"
 }
 
 # Keypair (as files on disk where Terraform is executed)
@@ -116,7 +117,7 @@ module "openstack_nat" {
   network_name                  = module.openstack_network.network_name
   keypair_name                  = openstack_compute_keypair_v2.master_keypair.name
   cluster_private_key_filename  = "${path.module}/cluster_key"
-  stackable_user                = local.stackable_user_name
+  stackable_user                = local.stackable_user
   network_ready_flag            = module.openstack_network.network_ready_flag
 }
 
@@ -128,7 +129,7 @@ module "openstack_protected_nodes" {
   network_name                  = module.openstack_network.network_name
   keypair_name                  = openstack_compute_keypair_v2.master_keypair.name
   cluster_private_key_filename  = "${path.module}/cluster_key"
-  stackable_user                = local.stackable_user_name
+  stackable_user                = local.stackable_user
   network_ready_flag            = module.openstack_network.network_ready_flag
 }
 
@@ -139,8 +140,9 @@ module "openstack_inventory" {
   nodes                         = module.openstack_protected_nodes.nodes
   cluster_private_key_filename  = "${path.module}/cluster_key"
   cluster_ip                    = module.openstack_network.cluster_ip
-  bastion_host_internal_ip       = module.openstack_nat.bastion_host_internal_ip
-  stackable_user                = local.stackable_user_name
+  bastion_host_internal_ip      = module.openstack_nat.bastion_host_internal_ip
+  stackable_user                = local.stackable_user
+  stackable_user_home           = local.stackable_user_home
 }
 
 # Creates the Stackable client script to access the cluster once it's up and running
@@ -151,5 +153,5 @@ module "stackable_client_script" {
   ]
   orchestrator_ip               = module.openstack_protected_nodes.orchestrator.access_ip_v4
   cluster_ip                    = module.openstack_network.cluster_ip
-  ssh-username                  = local.stackable_user_name
+  ssh-username                  = local.stackable_user
 }


### PR DESCRIPTION
We now have the `stackable_user` and `stackable_user_home` in every Ansible inventory so that we can de-duplicate some roles that formerly existed in two ('root' and 'non-root') or even more versions.