### PR TITLE
Added reverse dns lookup to T2 clusters

### DIFF
--- a/templates/_common/ansible_roles/bind_centos/tasks/main.yml
+++ b/templates/_common/ansible_roles/bind_centos/tasks/main.yml
@@ -13,6 +13,7 @@
   template: src={{ item.src }} dest=/var/named/{{ item.dest }}
   with_items:
     - { src: "stackable.zone.j2", dest: "stackable.zone"}
+    - { src: "stackable-reverse.zone.j2", dest: "stackable-reverse.zone"}
   notify:
     - reboot
 

--- a/templates/_common/ansible_roles/bind_centos/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/named.conf.j2
@@ -8,3 +8,8 @@ zone "{{ domain }}" in {
        type master;
        file "stackable.zone";
 };
+
+zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+        type master;
+        file "stackable-reverse.zone";
+};

--- a/templates/_common/ansible_roles/bind_centos/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/named.conf.j2
@@ -9,7 +9,8 @@ zone "{{ domain }}" in {
        file "stackable.zone";
 };
 
-zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
+zone "{{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}" in {
         type master;
         file "stackable-reverse.zone";
 };

--- a/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
@@ -15,6 +15,6 @@ $TTL 86400
 {% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
 $ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
 
-{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{{ internal_ip.split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
 {% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
@@ -1,5 +1,6 @@
-; BIND db file for {{ domain }}
+; BIND db reverse file for {{ domain }}
 
+$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -12,9 +13,6 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-
-$ORIGIN {{ domain }}.
-
-nat  IN      A    {{ hostvars[groups.nat[0]]['internal_ip'] }}
-{% for host in groups['protected'] %}{{ host }}  IN      A       {{ hostvars[host]['ansible_host']}}
+{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
 {% endfor %}

--- a/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/stackable-reverse.zone.j2
@@ -1,6 +1,5 @@
 ; BIND db reverse file for {{ domain }}
 
-$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -13,6 +12,9 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
-{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
+$ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
+
+{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/bind_centos/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/stackable.zone.j2
@@ -10,7 +10,7 @@ $TTL 86400
                         86400           ; Min TTL
 			)
 
-                NS      dns.{{ domain }}.
+@       IN      NS      dns.{{ domain }}.
 
 
 $ORIGIN {{ domain }}.

--- a/templates/_common/ansible_roles/bind_centos/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/bind_centos/templates/stackable.zone.j2
@@ -2,7 +2,7 @@
 
 $TTL 86400
 
-@       IN      SOA     dns.{{ domain }}.      soenke.liebau.opencore.com. (
+@       IN      SOA     dns.{{ domain }}.      info.stackable.de. (
                         2020063001	; serial number YYMMDDNN
                         28800           ; Refresh
                         7200            ; Retry

--- a/templates/_common/ansible_roles/nat_dns_centos/tasks/main.yml
+++ b/templates/_common/ansible_roles/nat_dns_centos/tasks/main.yml
@@ -13,6 +13,7 @@
   template: src={{ item.src }} dest=/var/named/{{ item.dest }}
   with_items:
     - { src: "stackable.zone.j2", dest: "stackable.zone"}
+    - { src: "stackable-reverse.zone.j2", dest: "stackable-reverse.zone"}
   notify:
     - reboot
 

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
@@ -9,7 +9,7 @@ zone "{{ domain }}" in {
        file "stackable.zone";
 };
 
-{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
 zone "{{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}" in {
         type master;
         file "stackable-reverse.zone";

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
@@ -8,3 +8,8 @@ zone "{{ domain }}" in {
        type master;
        file "stackable.zone";
 };
+
+zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+        type master;
+        file "stackable-reverse.zone";
+};

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/named.conf.j2
@@ -9,7 +9,8 @@ zone "{{ domain }}" in {
        file "stackable.zone";
 };
 
-zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+zone "{{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}" in {
         type master;
         file "stackable-reverse.zone";
 };

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
@@ -1,5 +1,6 @@
-; BIND db file for {{ domain }}
+; BIND db reverse file for {{ domain }}
 
+$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -12,9 +13,6 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-
-$ORIGIN {{ domain }}.
-
-nat  IN      A    {{ hostvars[groups.nat[0]]['internal_ip'] }}
-{% for host in groups['protected'] %}{{ host }}  IN      A       {{ hostvars[host]['ansible_host']}}
+{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
@@ -12,9 +12,9 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
 $ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
 
-{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{{ internal_ip.split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
 {% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable-reverse.zone.j2
@@ -1,6 +1,5 @@
 ; BIND db reverse file for {{ domain }}
 
-$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -13,6 +12,9 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
-{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
+{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+$ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
+
+{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
@@ -15,6 +15,6 @@ $TTL 86400
 
 $ORIGIN {{ domain }}.
 
-nat  IN      A    {{ hostvars[groups.nat[0]]['internal_ip'] }}
+nat  IN      A    {{ internal_ip }}
 {% for host in groups['protected'] %}{{ host }}  IN      A       {{ hostvars[host]['ansible_host']}}
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
@@ -2,7 +2,7 @@
 
 $TTL 86400
 
-@       IN      SOA     nat.{{ domain }}.      soenke.liebau.opencore.com. (
+@       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
                         2020063001	; serial number YYMMDDNN
                         28800           ; Refresh
                         7200            ; Retry

--- a/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_centos/templates/stackable.zone.j2
@@ -10,7 +10,7 @@ $TTL 86400
                         86400           ; Min TTL
 			)
 
-                NS      nat.{{ domain }}.
+@       IN      NS      nat.{{ domain }}.
 
 
 $ORIGIN {{ domain }}.

--- a/templates/_common/ansible_roles/nat_dns_debian/tasks/main.yml
+++ b/templates/_common/ansible_roles/nat_dns_debian/tasks/main.yml
@@ -13,6 +13,7 @@
   template: src={{ item.src }} dest=/var/cache/bind/{{ item.dest }}
   with_items:
     - { src: "stackable.zone.j2", dest: "stackable.zone"}
+    - { src: "stackable-reverse.zone.j2", dest: "stackable-reverse.zone"}
   notify:
     - reboot
 

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
@@ -9,7 +9,7 @@ zone "{{ domain }}" in {
        file "stackable.zone";
 };
 
-{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
 zone "{{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}" in {
         type master;
         file "stackable-reverse.zone";

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
@@ -8,3 +8,8 @@ zone "{{ domain }}" in {
        type master;
        file "stackable.zone";
 };
+
+zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+        type master;
+        file "stackable-reverse.zone";
+};

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/named.conf.j2
@@ -9,7 +9,8 @@ zone "{{ domain }}" in {
        file "stackable.zone";
 };
 
-zone "{{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}" in {
+{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+zone "{{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}" in {
         type master;
         file "stackable-reverse.zone";
 };

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
@@ -1,5 +1,6 @@
-; BIND db file for {{ domain }}
+; BIND db reverse file for {{ domain }}
 
+$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -12,9 +13,6 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-
-$ORIGIN {{ domain }}.
-
-nat  IN      A    {{ hostvars[groups.nat[0]]['internal_ip'] }}
-{% for host in groups['protected'] %}{{ host }}  IN      A       {{ hostvars[host]['ansible_host']}}
+{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
@@ -12,9 +12,9 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+{% set reverse_dns_domain_of_bastion_host = internal_ip | ipaddr('revdns') %}
 $ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
 
-{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{{ internal_ip.split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
 {% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/stackable-reverse.zone.j2
@@ -1,6 +1,5 @@
 ; BIND db reverse file for {{ domain }}
 
-$ORIGIN {{ hostvars[groups.nat[0]]['internal_ip'] | ansible.netcommon.ipaddr('revdns') | split('.')[1:] | join('.') }}.
 $TTL 86400
 
 @       IN      SOA     nat.{{ domain }}.      info.stackable.de. (
@@ -13,6 +12,9 @@ $TTL 86400
 
 @       IN      NS      nat.{{ domain }}.
 
-{{ hostvars[groups.nat[0]]['internal_ip'] | ip_last_octet }}  IN      A    nat
-{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'] | ip_last_octet }}  IN      PTR       {{ host }}
+{% set reverse_dns_domain_of_bastion_host = hostvars[groups.nat[0]]['internal_ip'] | ipaddr('revdns') %}
+$ORIGIN {{ reverse_dns_domain_of_bastion_host.split('.')[1:] | join('.') }}
+
+{{ hostvars[groups.nat[0]]['internal_ip'].split('.')[-1] }}  IN      PTR    nat.{{ domain }}.
+{% for host in groups['protected'] %}{{ hostvars[host]['ansible_host'].split('.')[-1] }}  IN      PTR       {{ host }}.{{ domain }}.
 {% endfor %}

--- a/templates/_common/ansible_roles/nat_dns_debian/templates/stackable.zone.j2
+++ b/templates/_common/ansible_roles/nat_dns_debian/templates/stackable.zone.j2
@@ -15,6 +15,6 @@ $TTL 86400
 
 $ORIGIN {{ domain }}.
 
-nat  IN      A    {{ hostvars[groups.nat[0]]['internal_ip'] }}
+nat  IN      A    {{ internal_ip }}
 {% for host in groups['protected'] %}{{ host }}  IN      A       {{ hostvars[host]['ansible_host']}}
 {% endfor %}

--- a/templates/_common/terraform_modules/aws_vpc/aws_vpc.tf
+++ b/templates/_common/terraform_modules/aws_vpc/aws_vpc.tf
@@ -21,10 +21,24 @@ resource "aws_route53_zone" "private" {
   }
 }
 
+resource "aws_route53_zone" "private_reverse" {
+  name = "1.0.10.in-addr.arpa"
+  vpc {
+    vpc_id = aws_vpc.vpc.id
+  }
+  tags = {
+    "Name" = "${var.name}-dns-zone-reverse"
+  }
+}
+
 output "vpc" {
   value = aws_vpc.vpc
 }
 
 output "dns_zone" {
   value = aws_route53_zone.private
+}
+
+output "dns_zone_reverse" {
+  value = aws_route53_zone.private_reverse
 }

--- a/templates/aws-centos-8/main.tf
+++ b/templates/aws-centos-8/main.tf
@@ -63,6 +63,7 @@ module "aws_protected_nodes" {
   cluster_private_key_filename  = "${path.module}/cluster_key"
   cluster_ip                    = module.aws_nat.cluster_ip
   dns_zone                      = module.aws_vpc.dns_zone
+  dns_zone_reverse              = module.aws_vpc.dns_zone_reverse
   stackable_user                = local.stackable_user
 }
 


### PR DESCRIPTION
We noticed during testing HDFS that reverse dns lookup has not been configured on bind for T2 deployed clusters, which caused datanodes to be rejected by the namenode.

I've created reverse zone file templates and added them to the tasks.

Disclaimer: 
I have not tested this, as creating a test jig to run this seemed to be too much effort. The filter to create the .in-addr.arpa. reverse netaddress is kinda ugly. That could probably be improved if we have a proper netmask in a variable somewhere instead of misusing the nat servers ip address for these calculations.