### PR TITLE
fixed Wireguard for AWS EC2

### DIFF
--- a/templates/_common/terraform_modules/aws_public/aws_public.tf
+++ b/templates/_common/terraform_modules/aws_public/aws_public.tf
@@ -90,6 +90,12 @@ resource "aws_security_group" "edge_node" {
     to_port = 22
     protocol = "tcp"
   }
+  ingress {
+    cidr_blocks = ["0.0.0.0/0"]
+    from_port = 0
+    to_port = 52888
+    protocol = "udp"
+  }
   egress {
     cidr_blocks = ["0.0.0.0/0"]
     from_port = 0

--- a/templates/aws-centos-8/launch.yml
+++ b/templates/aws-centos-8/launch.yml
@@ -5,6 +5,10 @@
 - hosts: edge
   roles: 
   - centos_epel_8
+  - role: edge_ip_forwarding_for_wireguard
+    when: wireguard|bool
+  - role: edge_wireguard_host
+    when: wireguard|bool
 - hosts: protected
   roles:
   - protected_node_common_centos


### PR DESCRIPTION
enabled Wireguard on AWS EC2 template
closes #98 