### PR TITLE
detect available versions from Helm repos

### DIFF
--- a/available-versions/Dockerfile
+++ b/available-versions/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:8
 # install helm
 RUN yum install curl -y
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -
-RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dummy-dev/
-RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-dummy-stable/
+RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
+RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 
 COPY cmd.sh /cmd.sh
 

--- a/available-versions/Dockerfile
+++ b/available-versions/Dockerfile
@@ -1,7 +1,10 @@
 FROM centos:8
 
-COPY stackable-releases.repo /etc/yum.repos.d/stackable-releases.repo
-COPY stackable-dev.repo /etc/yum.repos.d/stackable-dev.repo
+# install helm
+RUN yum install curl -y
+RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -
+RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
+RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 
 COPY cmd.sh /cmd.sh
 

--- a/available-versions/Dockerfile
+++ b/available-versions/Dockerfile
@@ -3,8 +3,8 @@ FROM centos:8
 # install helm
 RUN yum install curl -y
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -
-RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
-RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
+RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dummy-dev/
+RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-dummy-stable/
 
 COPY cmd.sh /cmd.sh
 

--- a/available-versions/cmd.sh
+++ b/available-versions/cmd.sh
@@ -1,2 +1,1 @@
-yum list available --showduplicates 2> /dev/null | grep 'stackable-agent.x86_64' | sed 's/.x86_64//' | sed 's/.el8//' | awk '{print $1"/"$2}' | sed 's/-0./-/' | sed 's/-0//' | sort -u
-yum list available --showduplicates 2> /dev/null | grep 'stackable' | grep 'operator' | sed 's/.x86_64//' | sed 's/.el8//' | awk '{print $1"/"$2}' | sed 's/-0./-/' | sed 's/-0//' | sort -u
+helm search repo --versions --devel

--- a/available-versions/cmd.sh
+++ b/available-versions/cmd.sh
@@ -1,2 +1,2 @@
-helm repo update
+helm repo update &>/dev/null
 helm search repo --versions --devel | grep 'stackable' | awk -F'/' '{print $2}' | sort | awk '{print $1"/"$2}'

--- a/available-versions/cmd.sh
+++ b/available-versions/cmd.sh
@@ -1,1 +1,2 @@
-helm search repo --versions --devel
+helm repo update
+helm search repo --versions --devel | grep 'stackable' | awk -F'/' '{print $2}' | sort | awk '{print $1"/"$2}'

--- a/available-versions/stackable-dev.repo
+++ b/available-versions/stackable-dev.repo
@@ -1,4 +1,0 @@
-[stackable-dev]
-name=Stackable Development
-baseurl=https://repo.stackable.tech/repository/rpm-dev/el8/
-gpgcheck=0

--- a/available-versions/stackable-releases.repo
+++ b/available-versions/stackable-releases.repo
@@ -1,4 +1,0 @@
-[stackable-releases]
-name=Stackable Releases
-baseurl=https://repo.stackable.tech/repository/rpm-release/el8/
-gpgcheck=0


### PR DESCRIPTION
The Docker image docker.stackable.tech/t2-available-versions which can be used to retrieve the available operator versions was updated to use the new Helm repos.