### PR TITLE
Hotfix: Hetzner CentOS 8 image change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>tech.stackable.t2</groupId>
 	<artifactId>t2-server</artifactId>
-	<version>2.3.0</version>
+	<version>2.3.1-SNAPSHOT</version>
 
 	<name>t2-server</name>
 	<licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 	<groupId>tech.stackable.t2</groupId>
 	<artifactId>t2-server</artifactId>
-	<version>2.3.1-SNAPSHOT</version>
+	<version>2.3.1</version>
 
 	<name>t2-server</name>
 	<licenses>

--- a/templates/_common/terraform_modules/hcloud/hcloud.tf
+++ b/templates/_common/terraform_modules/hcloud/hcloud.tf
@@ -17,7 +17,7 @@ variable "cluster_name" {
 }
 
 variable "os_image" {
-  description = "Image of the OS for the node, e.g. centos-8"
+  description = "Image of the OS for the node, e.g. centos-stream-8"
   type        = string
 }
 

--- a/templates/_common/terraform_modules/hcloud_edge_node/hcloud_edge_node.tf
+++ b/templates/_common/terraform_modules/hcloud_edge_node/hcloud_edge_node.tf
@@ -86,7 +86,7 @@ resource "hcloud_firewall" "edge_node" {
 resource "hcloud_server" "edge" {
   name        = "${var.cluster_name}-edge"
   server_type = "cx11"
-  image       = "centos-8"
+  image       = "centos-stream-8"
   location    = var.location
   ssh_keys    = [ var.keypair.id ]
 

--- a/templates/_common/terraform_modules/hcloud_protected_nodes/hcloud_protected_nodes.tf
+++ b/templates/_common/terraform_modules/hcloud_protected_nodes/hcloud_protected_nodes.tf
@@ -46,7 +46,7 @@ variable "cluster_private_key_filename" {
 }
 
 variable "os_image" {
-  description = "Image of the OS for the node, e.g. centos-8"
+  description = "Image of the OS for the node, e.g. centos-stream-8"
   type        = string
 }
 

--- a/templates/hcloud-centos-8/main.tf
+++ b/templates/hcloud-centos-8/main.tf
@@ -33,5 +33,5 @@ module "stackable_component_versions" {
 module "hcloud" {
   source                     = "./terraform_modules/hcloud"
   cluster_name               = var.cluster_name
-  os_image                   = "centos-8"
+  os_image                   = "centos-stream-8"
 }


### PR DESCRIPTION
The CentOS8 image on Hetzner is no longer available and will be replaced by CentOS8 Stream. Obviously, the (breaking) change has already be made in Terraform, so we had to change it.