### PR TITLE
Available Versions: include helm-test repo

### DIFF
--- a/available-versions/Dockerfile
+++ b/available-versions/Dockerfile
@@ -4,6 +4,7 @@ FROM centos:8
 RUN yum install curl -y
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -
 RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
+RUN helm repo add stackable-test https://repo.stackable.tech/repository/helm-test/
 RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
 
 COPY cmd.sh /cmd.sh


### PR DESCRIPTION
Included the new Helm repo in the set of repositories searched for available operator versions.