### PR TITLE
Fix IONOS templates

### DIFF
--- a/templates/_common/ansible_roles/ionos_fix_centos8_eol/tasks/main.yml
+++ b/templates/_common/ansible_roles/ionos_fix_centos8_eol/tasks/main.yml
@@ -1,0 +1,10 @@
+# Due to this: https://www.centos.org/centos-linux-eol/
+# Workaround found here: https://stackoverflow.com/a/70930049
+# We use this workaround as long as we are waiting for an official image from IONOS
+---
+- name: Fix YUM repo settings to mitigate CentOS8 EOL
+  shell: |
+    sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+  args:
+    warn: no

--- a/templates/ionos-centos-7/launch.yml
+++ b/templates/ionos-centos-7/launch.yml
@@ -5,6 +5,7 @@
   - firewalld
 - hosts: edge
   roles: 
+  - ionos_fix_centos8_eol
   - centos_epel_8
   - role: edge_ip_forwarding
     when: not (wireguard|bool)

--- a/templates/ionos-centos-7/main.tf
+++ b/templates/ionos-centos-7/main.tf
@@ -41,6 +41,6 @@ module "ionos" {
   source                        = "./terraform_modules/ionos"
   datacenter_name               = var.cluster_name
   os_name                       = "CentOS"
-  os_version                    = "7-server-2022-01-01"
+  os_version                    = "7-server-2022-02-01"
 }
 

--- a/templates/ionos-centos-8/launch.yml
+++ b/templates/ionos-centos-8/launch.yml
@@ -5,6 +5,7 @@
   - firewalld
 - hosts: edge
   roles: 
+  - ionos_fix_centos8_eol
   - centos_epel_8
   - role: edge_ip_forwarding
     when: not (wireguard|bool)
@@ -15,6 +16,7 @@
   - edge_bind
 - hosts: protected
   roles:
+  - ionos_fix_centos8_eol
   - protected_node_common_centos
   - protected_node_edge_as_gateway
   - protected_node_edge_as_dns

--- a/templates/ionos-debian-10/launch.yml
+++ b/templates/ionos-debian-10/launch.yml
@@ -5,6 +5,7 @@
 - hosts: edge
   roles:
   - firewalld
+  - ionos_fix_centos8_eol
   - centos_epel_8
   - role: edge_ip_forwarding
     when: not (wireguard|bool)

--- a/templates/ionos-debian-10/main.tf
+++ b/templates/ionos-debian-10/main.tf
@@ -41,6 +41,6 @@ module "ionos" {
   source                        = "./terraform_modules/ionos"
   datacenter_name               = var.cluster_name
   os_name                       = "Debian"
-  os_version                    = "10-server-2022-01-01"
+  os_version                    = "10-server-2022-02-01"
 }
 


### PR DESCRIPTION
The IONOS templates had to be fixed:
* CentOS8: introduced a workaround for repo useage due to EOL on 2022-01-31, see https://stackoverflow.com/a/70930049
* CentOS7: new template name at IONOS
* Debian10: new template name at IONOS