### PR TITLE
Removed legacy Spark Operator from T2 cluster setup

### DIFF
--- a/templates/_common/ansible_roles/stackable_operators/vars/main.yml
+++ b/templates/_common/ansible_roles/stackable_operators/vars/main.yml
@@ -1,6 +1,5 @@
 ---
 stackable_operators:
-  - spark-operator
   - spark-k8s-operator
   - zookeeper-operator
   - hbase-operator


### PR DESCRIPTION
see https://github.com/stackabletech/issues/issues/227