### PR TITLE
Add helm-test repository to T2 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN rm /tmp/kubectl
 RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash -s -
 RUN helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
 RUN helm repo add stackable-stable https://repo.stackable.tech/repository/helm-stable/
+RUN helm repo add stackable-test https://repo.stackable.tech/repository/helm-test/
 RUN helm repo update
 
 # install AWS CLI


### PR DESCRIPTION
#327 seems to have accidentally removed installation of the helm-test repo from the T2 docker file, causing tests that are run agains  -prxxx versions to fail, as the charts cannot be found.