### PR TITLE
Hetzner cluster location can be omitted

### DIFF
--- a/.ci/integration-tests/hetzner-centos-8/cluster.yaml
+++ b/.ci/integration-tests/hetzner-centos-8/cluster.yaml
@@ -9,6 +9,8 @@ domain: stackable.test
 publicKeys: []
 spec:
   wireguard: false
+  orchestrator:
+    serverType: cpx41
   nodes:
     main:
       numberOfNodes: 3

--- a/.ci/integration-tests/hetzner-centos-8/cluster.yaml
+++ b/.ci/integration-tests/hetzner-centos-8/cluster.yaml
@@ -8,7 +8,6 @@ metadata:
 domain: stackable.test
 publicKeys: []
 spec:
-  region: nbg1
   wireguard: false
   nodes:
     main:

--- a/.ci/integration-tests/hetzner-centos-stream-9/cluster.yaml
+++ b/.ci/integration-tests/hetzner-centos-stream-9/cluster.yaml
@@ -8,7 +8,6 @@ metadata:
 domain: stackable.test
 publicKeys: []
 spec:
-  region: nbg1
   wireguard: false
   nodes:
     main:

--- a/.ci/integration-tests/hetzner-debian-10/cluster.yaml
+++ b/.ci/integration-tests/hetzner-debian-10/cluster.yaml
@@ -8,7 +8,6 @@ metadata:
 domain: stackable.test
 publicKeys: []
 spec:
-  region: nbg1
   wireguard: false
   nodes:
     main:

--- a/docs/using-t2.adoc
+++ b/docs/using-t2.adoc
@@ -229,7 +229,7 @@ To keep the following informations somewhat handy, they are split in the options
 |domain |domain for DNS inside the cluster or when accessing through VPN 4+| 
 |publicKeys |list of SSH public keys to allow access to cluster nodes 4+| 
 |spec.region |one of the regions that the cloud vendor provides | e.g. `de/fra`, `de/txl` | e.g. `eu-central-1` 2+| not available
-|spec.location |one of the locations that the cloud vendor provides 3+| not available | e.g. `nbg1`, `hel1`
+|spec.location |one of the locations that the cloud vendor provides 3+| not available | HCloud datacenter location, e.g. `fsn1`, `nbg1`, `hel1`. If omitted (recommended and default), one location in central Europe is selected.
 |spec.cpuFamily |(optional) specify CPU-Family for all servers. The allowed values depend on the datacenter location you set up your cluster in. Please refer to your IONOS account for information about available CPUs and default values. | e.g. `INTEL_XEON` 3+| not available
 |spec.wireguard |(boolean, optional, defaults to `false`) Should a wireguard server be started on the bastion host? Leaving wireguard switched off when you don't need it speeds up the start of the cluster. | | not available | not available |
 |spec.k8sVersion |The K3s release to be installed. K3s offers a channel for each minor version of K8s, the channels are named `v1.21`, `v1.22` etc. Special channels are `stable` and `latest`. `stable` is the default for T2. See https://update.k3s.io/v1-release/channels[here, window="_blank"] to inspect which versions are the latest versions of each channel. 4+| 

--- a/docs/using-t2.adoc
+++ b/docs/using-t2.adoc
@@ -293,15 +293,18 @@ These are operators that Stackable currently provides. You can specify their ver
 [options="header"]
 |=======
 |Name |key
-|https://github.com/stackabletech/druid-operator[Stackable Operator for Apache Druid ] |`druid-operator`
-|https://github.com/stackabletech/hbase-operator[Stackable Operator for Apache HBase ] |`hbase-operator`
+|https://github.com/stackabletech/commons-operator[Stackable Commons Operator] |`commons-operator`
+|https://github.com/stackabletech/secret-operator[Stackable Secret Operator] |`secret-operator`
+|https://github.com/stackabletech/airflow-operator[Stackable Operator for Apache Airflow] |`airflow-operator`
+|https://github.com/stackabletech/druid-operator[Stackable Operator for Apache Druid] |`druid-operator`
+|https://github.com/stackabletech/hbase-operator[Stackable Operator for Apache HBase] |`hbase-operator`
 |https://github.com/stackabletech/hdfs-operator[Stackable Operator for Apache HDFS] |`hdfs-operator`
 |https://github.com/stackabletech/hive-operator[Stackable Operator for Apache Hive] |`hive-operator`
 |https://github.com/stackabletech/kafka-operator[Stackable Operator for Apache Kafka] |`kafka-operator`
 |https://github.com/stackabletech/monitoring-operator[Stackable Operator for Monitoring and Metrics] |`monitoring-operator`
 |https://github.com/stackabletech/nifi-operator[Stackable Operator for Apache NiFi] |`nifi-operator`
 |https://github.com/stackabletech/opa-operator[Stackable Operator for OpenPolicyAgent (OPA)] |`opa-operator`
-|https://github.com/stackabletech/spark-operator[Stackable Operator for Apache Spark] |`spark-operator`
+|https://github.com/stackabletech/spark-k8s-operator[Stackable Operator for Apache Spark] |`spark-k8s-operator`
 |https://github.com/stackabletech/superset-operator[Stackable Operator for Apache Superset] |`superset-operator`
 |https://github.com/stackabletech/trino-operator[Stackable Operator for Trino] |`trino-operator`
 |https://github.com/stackabletech/zookeeper-operator[Stackable Operator for Apache ZooKeeper] |`zookeeper-operator`

--- a/templates/_common/ansible_roles/collect_network_interface_facts/tasks/main.yml
+++ b/templates/_common/ansible_roles/collect_network_interface_facts/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: determine public network interface for edge node
+  shell: "ip -4 -o a | grep '{{ ansible_host }}' | head -1 | cut -d ' ' -f 2"
+  register: public_ip_output_edge
+  when: "'edge' == inventory_hostname"
+
+- name: determine private network interface for edge node
+  shell: "ip -4 -o a | grep '{{ internal_ip }}' | head -1 | cut -d ' ' -f 2"
+  register: private_ip_output_edge
+  when: "'edge' == inventory_hostname"
+
+- name: determine private network interface for protected nodes
+  shell: "ip -4 -o a | grep '{{ ansible_host }}' | head -1 | cut -d ' ' -f 2"
+  register: private_ip_output_protected
+  when: "'edge' != inventory_hostname"
+
+- name: set public network interface as Ansible fact (edge node)
+  set_fact:
+    public_network_interface_name: "{{ public_ip_output_edge.stdout }}"
+  when: "'edge' == inventory_hostname"
+
+- name: set private network interface as Ansible fact (edge node)
+  set_fact:
+    private_network_interface_name: "{{ private_ip_output_edge.stdout }}"
+  when: "'edge' == inventory_hostname"
+
+- name: set private network interface as Ansible fact (protected nodes)
+  set_fact:
+    private_network_interface_name: "{{ private_ip_output_protected.stdout }}"
+  when: "'edge' != inventory_hostname"

--- a/templates/_common/terraform_modules/hcloud/hcloud.tf
+++ b/templates/_common/terraform_modules/hcloud/hcloud.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/_common/terraform_modules/hcloud/hcloud.tf
+++ b/templates/_common/terraform_modules/hcloud/hcloud.tf
@@ -34,7 +34,7 @@ locals {
     ]
   ]): node.name => node }
 
-  location = can(yamldecode(file("cluster.yaml"))["spec"]["location"]) ? yamldecode(file("cluster.yaml"))["spec"]["location"] : "nbg1"
+  location = can(yamldecode(file("cluster.yaml"))["spec"]["location"]) ? yamldecode(file("cluster.yaml"))["spec"]["location"] : null
 }
 
 locals {

--- a/templates/_common/terraform_modules/hcloud_edge_node/hcloud_edge_node.tf
+++ b/templates/_common/terraform_modules/hcloud_edge_node/hcloud_edge_node.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/_common/terraform_modules/hcloud_inventory/templates/ansible-inventory.tpl
+++ b/templates/_common/terraform_modules/hcloud_inventory/templates/ansible-inventory.tpl
@@ -13,8 +13,6 @@ ansible_ssh_private_key_file=${ssh_key_private_path}
 wireguard=${wireguard}
 ansible_become=yes
 internal_ip=${edge_node_internal_ip}
-public_network_interface_name=eth0
-private_network_interface_name=ens10
 
 [orchestrators]
 orchestrator ansible_host=${element(orchestrator.network[*].ip, 0)}
@@ -33,4 +31,3 @@ ansible_ssh_common_args= -o ProxyCommand='ssh -o StrictHostKeyChecking=no -o Use
 ansible_ssh_private_key_file=${ssh_key_private_path}
 ansible_user=${stackable_user}
 ansible_become=yes
-private_network_interface_name=ens10

--- a/templates/_common/terraform_modules/hcloud_network/hcloud_network.tf
+++ b/templates/_common/terraform_modules/hcloud_network/hcloud_network.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/_common/terraform_modules/hcloud_protected_nodes/hcloud_protected_nodes.tf
+++ b/templates/_common/terraform_modules/hcloud_protected_nodes/hcloud_protected_nodes.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/hcloud-centos-8/launch.yml
+++ b/templates/hcloud-centos-8/launch.yml
@@ -2,6 +2,7 @@
 - hosts: all
   roles:
   - distribute_ssh_keys
+  - collect_network_interface_facts
 - hosts: edge
   roles: 
   - centos_epel_8

--- a/templates/hcloud-centos-8/main.tf
+++ b/templates/hcloud-centos-8/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/hcloud-centos-stream-9/launch.yml
+++ b/templates/hcloud-centos-stream-9/launch.yml
@@ -2,6 +2,7 @@
 - hosts: all
   roles:
   - distribute_ssh_keys
+  - collect_network_interface_facts
 - hosts: edge
   roles: 
   - centos_epel_9

--- a/templates/hcloud-centos-stream-9/main.tf
+++ b/templates/hcloud-centos-stream-9/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }

--- a/templates/hcloud-debian-10/launch.yml
+++ b/templates/hcloud-debian-10/launch.yml
@@ -2,6 +2,7 @@
 - hosts: all
   roles:
   - distribute_ssh_keys
+  - collect_network_interface_facts
 - hosts: edge
   roles: 
   - centos_epel_8

--- a/templates/hcloud-debian-10/main.tf
+++ b/templates/hcloud-debian-10/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     hcloud = {
       source = "hetznercloud/hcloud"
-      version = "1.33.1"
+      version = "1.35.1"
     }
   }
 }


### PR DESCRIPTION
(loosely coupled to #333)
Due to unavailable resources, we had some flaky HCloud-based tests recently. With this PR, it is allowed to omit the location and HCloud chooses a location where the requested resources are available.
In my tests, it worked fine, even mixed-location clusters/networks were possible. After the release of this feature, we should have an eye on the tests the following nights...