### PR TITLE
K9s installation is allowed to fail

### DIFF
--- a/templates/_common/ansible_roles/k9s/tasks/main.yml
+++ b/templates/_common/ansible_roles/k9s/tasks/main.yml
@@ -10,3 +10,4 @@
     exclude:
       - LICENSE
       - README.md
+  ignore_errors: yes

--- a/templates/_common/ansible_roles/k9s/tasks/main.yml
+++ b/templates/_common/ansible_roles/k9s/tasks/main.yml
@@ -3,7 +3,7 @@
 ---
 - name: install k9s
   unarchive:
-    src: https://github.com/derailed/k9s/releases/download/v0.25.18/k9s_Linux_x86_64.tar.gz
+    src: https://github.com/derailed/k9s/releases/download/v0.26.3/k9s_Linux_x86_64.tar.gz
     remote_src: yes
     dest: /usr/local/bin
     mode: 0755


### PR DESCRIPTION
The K9s installation no longer prevents the cluster launch from proceeding if it cannot be installed.