### PR TITLE
Write complete event logs in testdriver

### DIFF
--- a/templates/_common/ansible_roles/k3s_server/tasks/main.yml
+++ b/templates/_common/ansible_roles/k3s_server/tasks/main.yml
@@ -19,7 +19,8 @@
       --advertise-address {{ ansible_host }} \
       --node-ip {{ ansible_host }} \
       --flannel-iface {{ private_network_interface_name }} \
-      --node-taint CriticalAddonsOnly=true:NoExecute
+      --node-taint CriticalAddonsOnly=true:NoExecute \
+      --kube-apiserver-arg event-ttl=12h
   args:
     warn: no
     creates: /etc/rancher/k3s/k3s.yaml


### PR DESCRIPTION
In addition to tailing the logs using `kubectl ... --watch ...` which was a bit error-prone recently, we write the complete event logs from K8s API (in a long and an abbreviated version) to logfiles. This should mitigate the problems in https://github.com/stackabletech/infrastructure/issues/56 a bit, though it does not solve the actual problems.