### PR TITLE
GKE cluster admin with reduced permissions

### DIFF
--- a/templates/gke/main.tf
+++ b/templates/gke/main.tf
@@ -121,7 +121,7 @@ data "local_file" "gcloud_credentials" {
 
 resource "google_project_iam_member" "project" {
   project = var.google_cloud_project_id
-  role    = "roles/editor"
+  role    = "projects/t2-system-under-test/roles/t2.cluster.admin"
   member  = "serviceAccount:${google_service_account.cluster_admin.email}"
 }
 


### PR DESCRIPTION
The cluster admin now uses a role with reduced permissions so that this account cannot create/delete resources outside the K8s cluster