### PR TITLE
renamed 'Stackable versions' file to 'cluster-info.txt'

### DIFF
--- a/docs/using-t2.adoc
+++ b/docs/using-t2.adoc
@@ -614,13 +614,7 @@ The following files are created in the directory mounted into `/target/`:
 |=======
 |File |Description
 |`testdriver.log` | Log file of the testdriver container itself
-|`k8s-event.log` | Event stream of the Kubernetes cluster (one YAML per event)
-|`k8s-event-short.log` | Event stream of the Kubernetes cluster (one line per event)
-|`k8s-pod-change.log` | Pod changes stream of the Kubernetes cluster (one YAML per change)
-|`k8s-pod-change-short.log` | Pod changes stream of the Kubernetes cluster (one line per change)
-|`k8s-ping.log` | The testdriver "pings" (`kubectl get pods ...`) the (existing or managed) cluster every 5 seconds to document/test its connectivity. This file contains the results of these pings
-|`k8s-summary.log` | The summary of the K8s "pings" mentioned above (counts grouped by result type)
-|`stackable-versions.txt` | Text file containing the versions of the installed Stackable components in the cluster (if managed)
+|`cluster-info.txt` | Text file containing the versions of the installed Stackable components in the cluster (if managed)
 |`test-output.log` | Output of the test script
 |=======
 

--- a/src/main/java/tech/stackable/t2/api/cluster/controller/ClusterController.java
+++ b/src/main/java/tech/stackable/t2/api/cluster/controller/ClusterController.java
@@ -91,7 +91,7 @@ public class ClusterController {
 
     @GetMapping("{id}/stackable-versions")
     @ResponseBody
-    @Operation(summary = "read Stackable version information document", description = "Reads a text document which contains version information on installed Stackable components")
+    @Operation(summary = "read Stackable cluster information document", description = "Reads a text document which contains information about the cluster")
     public String getStackableVersions(
             @Parameter(name = "id", description = "ID (UUID) of the cluster") @PathVariable(name = "id", required = true) UUID id,
             @RequestHeader(name = "t2-token", required = false) String token) {
@@ -100,9 +100,9 @@ public class ClusterController {
         if (cluster == null) {
             throw new ClusterNotFoundException(String.format("No cluster found with id '%s'.", id));
         }
-        String stackableVersions = this.clusterService.getVersionInformation(id);
+        String stackableVersions = this.clusterService.getClusterInformation(id);
         if (stackableVersions == null) {
-            throw new ClusterNotFoundException(String.format("No Stackable version information document found for cluster with id '%s'.", id));
+            throw new ClusterNotFoundException(String.format("No Stackable cluster information document found for cluster with id '%s'.", id));
         }
         return stackableVersions;
     }

--- a/src/main/java/tech/stackable/t2/api/cluster/service/TerraformAnsibleClusterService.java
+++ b/src/main/java/tech/stackable/t2/api/cluster/service/TerraformAnsibleClusterService.java
@@ -173,14 +173,14 @@ public class TerraformAnsibleClusterService {
         }
     }
 
-    public String getVersionInformation(UUID id) {
+    public String getClusterInformation(UUID id) {
         Cluster cluster = this.clusters.get(id);
         if (cluster == null) {
             return null;
         }
         Path clusterBaseFolder = workspaceDirectory.resolve(cluster.getId().toString());
         try {
-            return FileUtils.readFileToString(clusterBaseFolder.resolve("resources/stackable-versions.txt").toFile(), StandardCharsets.UTF_8);
+            return FileUtils.readFileToString(clusterBaseFolder.resolve("resources/cluster-info.txt").toFile(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             LOGGER.warn("Stackable version information document could not be read", e);
             return null;

--- a/templates/_common/ansible_roles/cluster_info_sheet/tasks/main.yml
+++ b/templates/_common/ansible_roles/cluster_info_sheet/tasks/main.yml
@@ -7,14 +7,25 @@
 
 - name: Collect cluster info into file
   shell: |
-    kubectl --kubeconfig kubeconfig get nodes > resources/stackable-versions.txt
-    echo '' >> resources/stackable-versions.txt
-    kubectl --kubeconfig kubeconfig get nodes -o custom-columns=NAME:metadata.name,TAINTS:spec.taints,LOCATION:metadata.labels.location,NODE_LABEL:metadata.labels.node,NODE_SIZE:metadata.labels.node_size --sort-by=metadata.name >> resources/stackable-versions.txt
-    echo '' >> resources/stackable-versions.txt
-    echo '' >> resources/stackable-versions.txt
-  ignore_errors: True
-
-- name: Collect operator versions info into file
-  shell: |
-    helm --kubeconfig kubeconfig --namespace default list >> resources/stackable-versions.txt
+    echo 'Stackable test cluster configuration:' > resources/cluster-info.txt
+    echo '=====================================' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo 'Cloud vendor:               {{ metadata['annotations']['t2.stackable.tech/cloud-vendor'] | default("unknown", true) }}' >> resources/cluster-info.txt
+    echo 'Kubernetes distro:          {{ metadata['annotations']['t2.stackable.tech/k8s'] | default("unknown", true) }}' >> resources/cluster-info.txt
+    echo 'OS on Kubernetes nodes:     {{ metadata['annotations']['t2.stackable.tech/node-os'] | default("unknown", true) }}' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo 'Kubernetes nodes:' >> resources/cluster-info.txt
+    echo '-----------------' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    kubectl --kubeconfig kubeconfig get nodes >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    kubectl --kubeconfig kubeconfig get nodes -o custom-columns=NAME:metadata.name,TAINTS:spec.taints,LOCATION:metadata.labels.location,NODE_SIZE:metadata.labels.node_size --sort-by=metadata.name >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    echo 'Stackable operators:' >> resources/cluster-info.txt
+    echo '--------------------' >> resources/cluster-info.txt
+    echo '' >> resources/cluster-info.txt
+    helm --kubeconfig kubeconfig --namespace default list >> resources/cluster-info.txt
   ignore_errors: True

--- a/testdriver/testdriver.py
+++ b/testdriver/testdriver.py
@@ -47,8 +47,8 @@ CLUSTER_ACCESS_SCRIPT = "/access.sh"
 # constants for file handles (logfiles and the like)
 TESTDRIVER_LOGFILE = f"{TARGET_FOLDER}testdriver.log"
 TEST_OUTPUT_LOGFILE = f"{TARGET_FOLDER}test-output.log"
-STACKABLE_VERSIONS_FILE = f"{TARGET_FOLDER}stackable-versions.txt"
-OUTPUT_FILES = [ TESTDRIVER_LOGFILE, TEST_OUTPUT_LOGFILE, STACKABLE_VERSIONS_FILE]
+CLUSTER_INFO_FILE = f"{TARGET_FOLDER}cluster-info.txt"
+OUTPUT_FILES = [ TESTDRIVER_LOGFILE, TEST_OUTPUT_LOGFILE, CLUSTER_INFO_FILE]
 
 # misc constants
 CLUSTER_LAUNCH_TIMEOUT = 3600
@@ -390,7 +390,7 @@ def download_cluster_file(t2_url, t2_token, id, resource_name, destination_path)
 def download_cluster_files(t2_url, t2_token, id):
     """Downloads the various files belonging to the cluster using T2 REST API"""
     log("Downloading Stackable version information sheet for cluster from T2...")
-    download_cluster_file(t2_url, t2_token, id, "stackable-versions", STACKABLE_VERSIONS_FILE)
+    download_cluster_file(t2_url, t2_token, id, "stackable-versions", CLUSTER_INFO_FILE)
     log("Downloading cluster access file for cluster from T2...")
     download_cluster_file(t2_url, t2_token, id, "access", CLUSTER_ACCESS_FILE)
 


### PR DESCRIPTION
The REST endpoint remains unchanged for now to provide backwards compatibility. It should be changed in lockstep with the deployment of a new T2 release (both stages) as well as the T2 testdriver image